### PR TITLE
Fixes #18 missing/duplicate face in 2D convex hull

### DIFF
--- a/MIConvexHull/ConvexHull/ConvexHullAlgorithm.MainLoop.cs
+++ b/MIConvexHull/ConvexHull/ConvexHullAlgorithm.MainLoop.cs
@@ -601,7 +601,7 @@ namespace MIConvexHull
             var orderedPointList = new List<TVertex>();
             orderedPointList.Add(firstPoint);
             var orderedFaceList = new List<TFace>();
-            orderedFaceList.Add(faces[1]);
+            orderedFaceList.Add(faces[0]);
             var lowestXMinIndex = 0;
             var k = 0;
             while (!nextPoint.Equals(firstPoint))


### PR DESCRIPTION
fixes #18, faces[1] was being duplicated because orderedFaceList was not initialized with the first face and the loop starts processing the second face.